### PR TITLE
models: add credential schema

### DIFF
--- a/lib/models/credential.js
+++ b/lib/models/credential.js
@@ -1,0 +1,16 @@
+const MODEL_TYPES = require('../model_types')
+
+module.exports = {
+  path: 'credential',
+  name: 'Credential',
+  type: MODEL_TYPES.MAP,
+  schema: {
+    cid: String,
+    key: String,
+    secret: String,
+
+    exchangeData: Object
+  },
+
+  mapKey: ({ cid }) => (cid),
+}

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -1,11 +1,13 @@
 const AlgoOrder = require('./algo_order')
 const Backtest = require('./backtest')
 const Candle = require('./candle')
+const Credential = require('./credential')
 const Trade = require('./trade')
 
 module.exports = {
   AlgoOrder,
   Backtest,
   Candle,
+  Credential,
   Trade
 }


### PR DESCRIPTION
The hf client uses a lowdb instance to store credentials, it would be wise if we chucked that data into the same db instance as the rest of the hf services. This pr adds a credentials schema