### PR TITLE
Add upsert()/rename vol -> volume on Candle model, v2.0.1

### DIFF
--- a/lib/models/candle.js
+++ b/lib/models/candle.js
@@ -9,7 +9,7 @@ module.exports = {
     high: Number,
     low: Number,
     close: Number,
-    vol: Number,
+    volume: Number,
 
     exchange: String,
     symbol: String,

--- a/lib/models/candle.js
+++ b/lib/models/candle.js
@@ -4,6 +4,8 @@ module.exports = {
   path: 'candles',
   name: 'Candle',
   type: MODEL_TYPES.COLLECTION,
+  index: 'key',
+  indexMatches: ['key'],
   schema: {
     open: Number,
     high: Number,

--- a/lib/validate/adapter.js
+++ b/lib/validate/adapter.js
@@ -6,7 +6,8 @@ const _isString = require('lodash/isString')
 const _isEmpty = require('lodash/isEmpty')
 
 const REQUIRED_COLLECTION_METHODS = [
-  'find', 'getAll', 'getInRange', 'insert', 'bulkInsert', 'rmAll', 'update'
+  'find', 'getAll', 'getInRange', 'insert', 'bulkInsert', 'rmAll', 'update',
+  'upsert',
 ]
 
 const REQUIRED_GENERIC_METHODS = ['raw']

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-models",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "HF DB models (lowdb)",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Adds `index` and `indexMatches` fields to the Candle model for `upsert()`