### PR TITLE
v2.1.0: Market & Strategy models, add meta to Credential

### DIFF
--- a/lib/models/credential.js
+++ b/lib/models/credential.js
@@ -8,6 +8,7 @@ module.exports = {
     cid: String,
     key: String,
     secret: String,
+    meta: String,
 
     exchangeData: Object
   },

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -3,11 +3,15 @@ const Backtest = require('./backtest')
 const Candle = require('./candle')
 const Credential = require('./credential')
 const Trade = require('./trade')
+const Market = require('./market')
+const Strategy = require('./strategy')
 
 module.exports = {
   AlgoOrder,
   Backtest,
   Candle,
   Credential,
-  Trade
+  Trade,
+  Market,
+  Strategy,
 }

--- a/lib/models/market.js
+++ b/lib/models/market.js
@@ -1,0 +1,17 @@
+const MODEL_TYPES = require('../model_types')
+
+module.exports = {
+  path: 'markets',
+  name: 'Market',
+  type: MODEL_TYPES.COLLECTION,
+  schema: {
+    exchange: String,
+    quote: String,
+    base: String,
+    wsID: String,
+    restID: String,
+    uiID: String,
+
+    exchangeData: Object
+  },
+}

--- a/lib/models/strategy.js
+++ b/lib/models/strategy.js
@@ -1,0 +1,30 @@
+const MODEL_TYPES = require('../model_types')
+
+module.exports = {
+  path: 'strategies',
+  name: 'Strategy',
+  type: MODEL_TYPES.MAP,
+  schema: {
+    id: String,
+
+    label: String,
+    cryptedLabel: String,
+
+    defineIndicators: String,
+    onPriceUpdate: String,
+    onEnter: String,
+    onUpdate: String,
+    onUpdateLong: String,
+    onUpdateShort: String,
+    onUpdateClosing: String,
+    onPositionOpen: String,
+    onPositionUpdate: String,
+    onPositionClose: String,
+    onStart: String,
+    onStop: String,
+
+    exchangeData: Object
+  },
+
+  mapKey: ({ id }) => id,
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-models",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "HF DB models (lowdb)",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
* Adds `Market` and `Strategy` models
* Adds a `meta` key to the `Credential` model
* bumps manifest to 2.1.0