### PR TITLE
v2.1.2 Fix: Default model methods are overwritten w/ multiple DB instances

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 2.1.2
+- fix: return new POJO default models for each db instance
+
 # 2.1.1
 - manifest: bump deps
 - meta: add github issue/pr templates

--- a/lib/models/algo_order.js
+++ b/lib/models/algo_order.js
@@ -1,6 +1,6 @@
 const MODEL_TYPES = require('../model_types')
 
-module.exports = {
+module.exports = () => ({
   path: 'algo_orders',
   name: 'Algo Order',
   type: MODEL_TYPES.MAP,
@@ -14,4 +14,4 @@ module.exports = {
   },
 
   mapKey: ({ gid, algoID }) => (`${gid}-${algoID}`)
-}
+})

--- a/lib/models/backtest.js
+++ b/lib/models/backtest.js
@@ -1,6 +1,6 @@
 const MODEL_TYPES = require('../model_types')
 
-module.exports = {
+module.exports = () => ({
   path: 'backtests',
   name: 'Backtest',
   type: MODEL_TYPES.MAP,
@@ -19,4 +19,4 @@ module.exports = {
   },
 
   mapKey: ({ btID, strategyID }) => (`${btID}-${strategyID}`)
-}
+})

--- a/lib/models/candle.js
+++ b/lib/models/candle.js
@@ -1,6 +1,6 @@
 const MODEL_TYPES = require('../model_types')
 
-module.exports = {
+module.exports = () => ({
   path: 'candles',
   name: 'Candle',
   type: MODEL_TYPES.COLLECTION,
@@ -25,4 +25,4 @@ module.exports = {
     'syncRange',
     'auditGaps'
   ]
-}
+})

--- a/lib/models/credential.js
+++ b/lib/models/credential.js
@@ -1,6 +1,6 @@
 const MODEL_TYPES = require('../model_types')
 
-module.exports = {
+module.exports = () => ({
   path: 'credential',
   name: 'Credential',
   type: MODEL_TYPES.MAP,
@@ -14,4 +14,4 @@ module.exports = {
   },
 
   mapKey: ({ cid }) => (cid)
-}
+})

--- a/lib/models/market.js
+++ b/lib/models/market.js
@@ -1,6 +1,6 @@
 const MODEL_TYPES = require('../model_types')
 
-module.exports = {
+module.exports = () => ({
   path: 'markets',
   name: 'Market',
   type: MODEL_TYPES.COLLECTION,
@@ -14,4 +14,4 @@ module.exports = {
 
     exchangeData: Object
   }
-}
+})

--- a/lib/models/strategy.js
+++ b/lib/models/strategy.js
@@ -1,6 +1,6 @@
 const MODEL_TYPES = require('../model_types')
 
-module.exports = {
+module.exports = () => ({
   path: 'strategies',
   name: 'Strategy',
   type: MODEL_TYPES.MAP,
@@ -27,4 +27,4 @@ module.exports = {
   },
 
   mapKey: ({ id }) => id
-}
+})

--- a/lib/models/trade.js
+++ b/lib/models/trade.js
@@ -1,6 +1,6 @@
 const MODEL_TYPES = require('../model_types')
 
-module.exports = {
+module.exports = () => ({
   path: 'trades',
   name: 'Trade',
   type: MODEL_TYPES.COLLECTION,
@@ -17,4 +17,4 @@ module.exports = {
   requiredMethods: [
     'syncRange'
   ]
-}
+})

--- a/lib/util/process_schema.js
+++ b/lib/util/process_schema.js
@@ -27,7 +27,7 @@ module.exports = (schema) => {
       return
     }
 
-    const defaultModel = defaultModels[name]
+    const defaultModel = defaultModels[name]()
 
     // Assign default schema if models don't provide their own
     Object.keys(defaultModel).forEach(key => {
@@ -48,7 +48,7 @@ module.exports = (schema) => {
   // Include builtin models if not present on schema
   defaultModelNames.forEach(defaultModelName => {
     if (!_includes(modelNames, defaultModelName)) {
-      processed[defaultModelName] = defaultModels[defaultModelName]
+      processed[defaultModelName] = defaultModels[defaultModelName]()
     }
   })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-models",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "HF DB models",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This bug was exposed in `bfx-hf-server`, where creating the algo server DB instance overwrites the model methods for all other DB instances (UI, data servers).

Specifically, within `lib/util/process_schema.js` default models are attached to the incoming schema if not already present and configured with the adapter the HFDB instance was created with. The bug is due to the fact that default models are exported as POJOs and therefore shared among all `processSchema()` invocations, so each successive invocation replaces the adapter used by the model (meaning DB path, among other things).

This PR refactors the model files to export functions, returning fresh POJOs for the methods to be attached to.

### TODO
* [x] merge & rebase https://github.com/bitfinexcom/bfx-hf-models/pull/6
* [x] bump version (`v2.1.2` after PR 6)
* [x] update changelog
* [x] self review
